### PR TITLE
Adding the DiscordCommunicationService

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 *.iml
 
 .vertx
+.java-version

--- a/README.md
+++ b/README.md
@@ -106,3 +106,7 @@ redis.enabled             |boolean              |false          |Enables Redis f
 redis.host                |String               |redis          |Redis Hostname. Only relevant if redis.enabled=true
 redis.port                |int                  |6379           |Redis Port. Only relevant if redis.enabled=true
 redis.history.expire      |long                 |24*60*60       |Seconds since the last update until redis expires all history for a volatile channel (channel starting with ?)
+discord.enabled           |boolean              |false          |Enables Discord integration
+discord.token             |String               |               |The Discord bot token needed to authenticate
+discord.channels.incoming |JsonObject           |               |Map Discord-Channel-Id -> EventServer-Channel.  Example: {"727383179484463105":"GLOBAL"}
+discord.channels.outgoing |JsonObject           |               |Map EventServer-Channel -> Discord-Channel-Id

--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,8 @@ dependencies {
     compile 'io.prometheus:simpleclient:0.1.0'
     compile 'io.prometheus:simpleclient_hotspot:0.1.0'
     compile 'io.prometheus:simpleclient_vertx:0.1.0'
+
+    compile 'com.discord4j:discord4j-core:3.1.0.RC2'
 }
 
 run {

--- a/src/main/java/com/universeprojects/eventserver/CommunicationService.java
+++ b/src/main/java/com/universeprojects/eventserver/CommunicationService.java
@@ -1,0 +1,254 @@
+package com.universeprojects.eventserver;
+
+import io.vertx.core.eventbus.Message;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
+import io.vertx.core.shareddata.Lock;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public abstract class CommunicationService {
+
+    private static final String CONFIG_ENABLED = "enabled";
+    private static final String CONFIG_PROCESS_HTML = "process.html";
+    private static final String CONFIG_CHANNELS_INCOMING = "channels.incoming";
+    private static final String CONFIG_CHANNELS_OUTGOING = "channels.outgoing";
+    private static final int FAILOVER_CHECK_TIME = 60 * 1000;
+    protected static final String DATA_MARKER_FROM = "__from";
+    private static final String DATA_AUTHOR_LINK = "AuthorLink";
+    private static final String DATA_AUTHOR_COLOR = "AuthorColor";
+    private static final String DATA_ADDITIONAL_FIELDS = "AdditionalFields";
+
+    private final Logger log = LoggerFactory.getLogger(getClass());
+
+    protected final EventServerVerticle verticle;
+    protected final String serviceName;
+    private final boolean enabled;
+    protected final Map<String, String> outgoingChannelMap;
+    protected final Map<String, String> incomingChannelMap;
+    private final Object timerLock = new Object();
+    private Lock instanceLock;
+    private Long timerId;
+    private boolean processHtml;
+
+    private String prefixConfig(String config) {
+        return serviceName.toLowerCase() + "." + config;
+    }
+
+    private Map<String, String> processMap(String channels) {
+        if(channels != null) {
+            Map<String, String> map = new LinkedHashMap<>();
+            JsonObject json = new JsonObject(channels);
+            for(Map.Entry<String, Object> entry : json.getMap().entrySet()) {
+                map.put(entry.getKey(), (String) entry.getValue());
+            }
+            return Collections.unmodifiableMap(map);
+        } else {
+            return Collections.emptyMap();
+        }
+    }
+
+    public CommunicationService(EventServerVerticle verticle, String serviceName) {
+        this.verticle = Objects.requireNonNull(verticle);
+        this.serviceName = Objects.requireNonNull(serviceName);
+        this.enabled = Config.getBoolean(prefixConfig(CONFIG_ENABLED), false);
+        this.processHtml = Config.getBoolean(prefixConfig(CONFIG_PROCESS_HTML), false);
+        this.outgoingChannelMap = processMap(Config.getString(prefixConfig(CONFIG_CHANNELS_OUTGOING), null));
+        this.incomingChannelMap = processMap(Config.getString(prefixConfig(CONFIG_CHANNELS_INCOMING), null));
+        verticle.logConnectionEvent(() -> "Started Service " + toString());
+    }
+
+    abstract boolean localCanActivateOutgoing();
+
+    private boolean canActivateOutgoing() {
+        return enabled && !outgoingChannelMap.isEmpty() && localCanActivateOutgoing();
+    }
+
+    abstract boolean localCanActivateIncoming();
+
+    private boolean canActivateIncoming() {
+        return enabled && !incomingChannelMap.isEmpty() && localCanActivateIncoming();
+    }
+
+    protected void sendInsideMessage(String insideChannel, String outsideChannel, String userName, String text, Long timestamp) {
+        String address = verticle.generateChannelAddress(insideChannel);
+        ChatMessage chatMessage = new ChatMessage();
+        chatMessage.channel = insideChannel;
+        chatMessage.senderDisplayName = userName;
+        chatMessage.senderUserId = "remote:"+outsideChannel;
+        chatMessage.text = text;
+        chatMessage.timestamp = timestamp;
+        chatMessage.additionalData = new JsonObject().put(DATA_MARKER_FROM + serviceName , true);
+        verticle.logConnectionEvent(() -> "Publishing message from remote channel "+outsideChannel+" to channel "+insideChannel+": "+chatMessage);
+        verticle.eventBus.publish(address, chatMessage);
+        verticle.storeChatHistory(insideChannel, Collections.singletonList(chatMessage));
+    }
+
+    @SuppressWarnings("unused")
+    public boolean isActive() {
+        return (canActivateIncoming() || canActivateOutgoing()) && instanceLock != null;
+    }
+
+    public void activate() {
+        if (canActivateIncoming() || canActivateOutgoing()) {
+            verticle.logConnectionEvent(() -> "Attempting to acquire lock for " + serviceName);
+            verticle.sharedDataService.getCommunicationsLock(serviceName.toLowerCase(), (result) -> {
+                if (result.succeeded()) {
+                    instanceLock = result.result();
+                    log.info("Acquired " + serviceName + " lock - activating message-service");
+                    cancelTimer();
+                    if (canActivateOutgoing()) {
+                        activateOutgoing();
+                    }
+                    if (canActivateIncoming()) {
+                        activateIncoming();
+                    }
+                } else {
+                    log.info("Failed to acquire " + serviceName + " lock", result.cause());
+                    setupTimer();
+                }
+            });
+        }
+    }
+
+    protected void activateOutgoing() {
+        setupHandlers();
+    }
+
+    abstract void activateIncoming();
+
+    private void setupTimer() {
+        synchronized (timerLock) {
+            if (timerId != null) return;
+            verticle.logConnectionEvent(() -> "Unable to acquire slack lock - setting up timer");
+            timerId = verticle.getVertx().setPeriodic(FAILOVER_CHECK_TIME, (ignored) -> activate());
+        }
+    }
+
+    private void cancelTimer() {
+        synchronized (timerLock) {
+            if (timerId == null) return;
+            verticle.getVertx().cancelTimer(timerId);
+            timerId = null;
+        }
+    }
+
+    private void setupHandlers() {
+        for(Map.Entry<String, String> entry : outgoingChannelMap.entrySet()) {
+            String insideChannel = entry.getKey();
+            String outsideChannel = entry.getValue();
+            verticle.eventBus.<ChatMessage>consumer(verticle.generateChannelAddress(insideChannel),
+                    (message) -> processChannelMessage(message, outsideChannel)
+            );
+        }
+    }
+
+    private void processChannelMessage(Message<ChatMessage> message, String remoteChannel) {
+        ChatMessage chatMessage = message.body();
+        String channel = chatMessage.channel;
+        if(chatMessage.text == null) {
+            return;
+        }
+        JsonObject additionalData = chatMessage.additionalData;
+        String authorLink = null;
+        String authorColor = null;
+        JsonArray additionalFields = null;
+        if(additionalData != null)  {
+            Boolean fromUs = additionalData.getBoolean(DATA_MARKER_FROM + serviceName, false);
+            if(fromUs != null && fromUs) {
+                return;//Prevent loops
+            }
+            authorLink = additionalData.getString(serviceName + DATA_AUTHOR_LINK);
+            authorColor = additionalData.getString(serviceName + DATA_AUTHOR_COLOR);
+            additionalFields = additionalData.getJsonArray(serviceName + DATA_ADDITIONAL_FIELDS);
+        }
+
+        String text = processText(chatMessage.text, processHtml);
+        String fallbackText = processText(chatMessage.text, false);
+
+        sendOutsideMessage(channel, remoteChannel, text, fallbackText, chatMessage.senderDisplayName, authorLink, authorColor, additionalFields);
+
+
+    }
+
+    abstract void sendOutsideMessage(String sourceChannel, String remoteChannel, String text, String fallbackText, String author, String authorLink, String authorColor, JsonArray additionalFields);
+
+    private final Pattern linkPattern = Pattern.compile("<\\s*a\\s+href=\"([^\"]*)\"\\s*>([^<]+)<\\/a\\s*>");
+    private final Pattern boldPattern = Pattern.compile("<\\s*b\\s*>([^<]+)<\\/b\\s*>");
+    private final Pattern strongPattern = Pattern.compile("<\\s*strong\\s*>([^<]+)<\\/strong\\s*>");
+    private final Pattern italicPattern = Pattern.compile("<\\s*i\\s*>([^<]+)<\\/i\\s*>");
+    private final Pattern emPattern = Pattern.compile("<\\s*em\\s*>([^<]+)<\\/em\\s*>");
+
+    private String processText(final String str, final boolean translateHtml) {
+        String text = str;
+        final Matcher linkMatcher = linkPattern.matcher(text);
+        if(translateHtml) {
+            text = linkMatcher.replaceAll("!!l!!$1|$2!!g!!");
+        } else {
+            text = linkMatcher.replaceAll("$2");
+        }
+
+        final Matcher boldMatcher = boldPattern.matcher(text);
+        if(translateHtml) {
+            text = boldMatcher.replaceAll("*$1*");
+        } else {
+            text = boldMatcher.replaceAll("$1");
+        }
+
+        final Matcher strongMatcher = strongPattern.matcher(text);
+        if(translateHtml) {
+            text = strongMatcher.replaceAll("*$1*");
+        } else {
+            text = strongMatcher.replaceAll("$1");
+        }
+
+        final Matcher italicMatcher = italicPattern.matcher(text);
+        if(translateHtml) {
+            text = italicMatcher.replaceAll("_$1_");
+        } else {
+            text = italicMatcher.replaceAll("$1");
+        }
+
+        final Matcher emMatcher = emPattern.matcher(text);
+        if(translateHtml) {
+            text = emMatcher.replaceAll("_$1_");
+        } else {
+            text = emMatcher.replaceAll("$1");
+        }
+
+        if(translateHtml) {
+            text = text.replaceAll("<\\s*br\\s*/?>", "\\n");
+        } else {
+            text = text.replaceAll("<\\s*br\\s*/?>", "");
+        }
+
+        text = escapeMessage(text);
+
+        if(processHtml) {
+            text = text.replaceAll("!!l!!", "<");
+            text = text.replaceAll("!!g!!", ">");
+        }
+
+        return text;
+    }
+
+    private String escapeMessage(String str) {
+        return str.
+            replaceAll("&", "%amp;").
+            replaceAll("<", "&lt;").
+            replaceAll(">","&gt;");
+    }
+
+    protected static void putIfNotNull(JsonObject object, String key, String data) {
+        if(data != null) {
+            object.put(key, data);
+        }
+    }
+}

--- a/src/main/java/com/universeprojects/eventserver/DiscordCommunicationService.java
+++ b/src/main/java/com/universeprojects/eventserver/DiscordCommunicationService.java
@@ -1,0 +1,76 @@
+package com.universeprojects.eventserver;
+
+import discord4j.common.util.Snowflake;
+import discord4j.core.DiscordClient;
+import discord4j.core.GatewayDiscordClient;
+import discord4j.core.event.domain.message.MessageCreateEvent;
+import discord4j.core.event.domain.message.MessageUpdateEvent;
+import discord4j.core.object.entity.Message;
+import discord4j.core.object.entity.User;
+import discord4j.core.object.entity.channel.MessageChannel;
+import io.vertx.core.json.JsonArray;
+
+import java.util.Optional;
+import java.util.function.Consumer;
+
+public class DiscordCommunicationService extends CommunicationService {
+
+    private static final String SERVICE_NAME = "Discord";
+    private static final String CONFIG_DISCORD_TOKEN = "discord.token";
+
+    private final String token;
+    private GatewayDiscordClient gateway;
+
+    public DiscordCommunicationService(EventServerVerticle verticle) {
+        super(verticle, SERVICE_NAME);
+        token = Config.getString(CONFIG_DISCORD_TOKEN, null);
+    }
+
+    boolean localCanActivateOutgoing() {
+        return localCanActivateIncoming();
+    }
+
+    boolean localCanActivateIncoming() {
+        return token != null && token.length() > 0;
+    }
+
+    void activateIncoming() {
+        DiscordClient client = DiscordClient.create(token);
+        gateway = client.login().block();
+
+        final Consumer<MessageCreateEvent> handleMessage = event -> {
+            final Message message = event.getMessage();
+            final MessageChannel channel = message.getChannel().block();
+            final String discordChannel = Long.toString(channel.getId().asLong());
+            final String discordChannelName = channel.getMention();
+            final Optional<User> author = message.getAuthor();
+            final boolean isBot = author.map(user -> user.isBot()).orElse(false);
+            if (incomingChannelMap.containsKey(discordChannel) && !isBot) {
+                final String insideChannel = incomingChannelMap.get(discordChannel);
+                final String username = author.map(user -> user.getUsername()).orElse("unknown");
+                sendInsideMessage(insideChannel, discordChannel, username, message.getContent(), message.getTimestamp().getEpochSecond());
+            }
+        };
+
+        final Consumer<MessageUpdateEvent> updateMessage = event -> {
+            verticle.logConnectionEvent(() -> "Received an edited message from discord channel " + Long.toString(event.getChannelId().asLong()));
+        };
+
+        gateway.on(MessageCreateEvent.class).subscribe(handleMessage);
+        gateway.on(MessageUpdateEvent.class).subscribe(updateMessage);
+    }
+
+    void sendOutsideMessage(String sourceChannel, String remoteChannel, String text, String fallbackText, String author, String authorLink, String authorColor, JsonArray additionalFields) {
+        final MessageChannel channel = (MessageChannel) gateway.getChannelById(Snowflake.of(Long.parseLong(remoteChannel))).block();
+        channel.createMessage(author + ": " + text).block();
+    }
+
+    @Override
+    public String toString() {
+        return "DiscordCommunicationService{" +
+                "active= " + isActive() +
+                ", outgoingChannelMap=" + outgoingChannelMap +
+                ", incomingChannelMap=" + incomingChannelMap +
+                '}';
+    }
+}

--- a/src/main/java/com/universeprojects/eventserver/EventServerVerticle.java
+++ b/src/main/java/com/universeprojects/eventserver/EventServerVerticle.java
@@ -49,6 +49,7 @@ public class EventServerVerticle extends AbstractVerticle {
     public SharedDataService sharedDataService;
     public ServerMode serverMode;
     public SlackCommunicationService slackCommunicationService;
+    public DiscordCommunicationService discordCommunicationService;
     public HistoryService historyService;
     public ChannelService channelService;
     public UserService userService;
@@ -119,6 +120,9 @@ public class EventServerVerticle extends AbstractVerticle {
         slackCommunicationService = new SlackCommunicationService(this);
         slackCommunicationService.activate();
         slackCommunicationService.setupRoute(router);
+
+        discordCommunicationService = new DiscordCommunicationService(this);
+        discordCommunicationService.activate();
 
         server.requestHandler(router::accept).listen(port, "0.0.0.0");
         log.info("Server started up at http://localhost:" + port);

--- a/src/main/java/com/universeprojects/eventserver/SharedDataService.java
+++ b/src/main/java/com/universeprojects/eventserver/SharedDataService.java
@@ -18,6 +18,10 @@ public class SharedDataService {
         sd.getLockWithTimeout("slack", 10 * 1000, handler);
     }
 
+    public void getCommunicationsLock(String name, Handler<AsyncResult<Lock>> handler) {
+        sd.getLockWithTimeout(name, 10 * 1000, handler);
+    }
+
     public void getChannelLock(String key, Handler<AsyncResult<Lock>> handler) {
         sd.getLockWithTimeout("messages:"+key, 1000, handler);
     }


### PR DESCRIPTION
This service will proxy messages from Discord channels to EventServer channels.

This adds two new classes: 
* `CommunicationService` - This is an abstract class that implements the basic, common code found in the `SlackCommunicationService` in a way that all Communication classes can share.
* `DiscordCommunicationService` - This is an implementation of the Discord integration using `CommunicationService` as a base.

Once this has been approved and tested, `SlackCommunicationService` can be easily refactored to extend `CommunicationService`.